### PR TITLE
chore(): chrome version to 75

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,9 @@
-FROM cypress/browsers:node11.13.0-chrome73
+FROM cypress/browsers:node10.11.0-chrome75
 
 # In order to be able to just run cypress (i.e. just `cypress` and not `yarn cypress`).
 # We need to run cypress globally otherwise we get the error 'Could not find any tests to run.'
 RUN yarn global add \
     cypress
-
-# Need to install dependencies local in order to be found. Cypress is needed to find its typings.
-# Ignore version-check of engines since some dependencies require an older version of node.
-RUN yarn add \
-    @cypress/webpack-preprocessor@4.0.3 \
-    @types/mocha@5.2.5 \
-    cypress@3.1.5 \
-    ts-loader@5.3.3 \
-    tsconfig-paths-webpack-plugin@3.2.0 \
-    typescript@3.2.4 \
-    webpack@4.29.0 \
-    --ignore-engines
 
 # This image uses the root user. You might want to switch to non-root user when
 # running this container for security.


### PR DESCRIPTION
Also we probably don't need anymore to install the dependencies

```
 node version:    v10.11.0 
 npm version:     6.9.0 
 yarn version:    1.16.0 
 debian version:  8.11 
 Chrome version:  Google Chrome 75.0.3770.100  
 git version:     git version 2.1.4
```